### PR TITLE
Adding CNAME for scalapuzzlers.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+scalapuzzlers.com


### PR DESCRIPTION
See http://help.github.com/pages/ under "Custom Domains". DNS is already set up on ns19.xenserve.com, test using

...>nslookup scalapuzzlers.com ns19.xenserve.com
Server:  server10.xenserve.com
Address:  80.82.118.233

Name:    scalapuzzlers.com
Address:  204.232.175.78

Now just waiting for those changes to propagate.
