### PR TITLE
Puzzler 21: Top-Level

### DIFF
--- a/puzzlers/pzzlr-021.html
+++ b/puzzlers/pzzlr-021.html
@@ -1,8 +1,8 @@
 <h1>Top-Level</h1>
-<table class="table table-condensed">
+<table class="table meta-table table-condensed">
   <tbody>
     <tr>
-      <td><strong>Contributed by</strong></td>
+      <td class="header-column"><strong>Contributed by</strong></td>
       <td>Dominik Gruntz</td>
     </tr>
     <tr>
@@ -17,44 +17,51 @@
 </table>
 <div class="code-snippet">
 <h3>What is the result of executing the following code?</h3>
+Note: This example cannot <a href="https://issues.scala-lang.org/browse/SI-5299">currently</a> be run from the REPL (as it contains a package definition).
+Copy the sample into a file and compile with <tt>scalac</tt>.
 <pre class="prettyprint lang-scala">
 object base {
   class X { val context = "object base" }
 }
 
 package base {
-  class X { val context = "package base" }
+  class Y { val context = "package base" }
 }
 
 object Main extends App {
   println((new base.X).context)
-  
-  import base.X
-  println((new X).context)
-} 
+  println((new base.Y).context)
+}
 </pre>
 
 <ol>
-<li>Fails with a compile-time error.
+<li>Fails with the compile-time error
+<pre class="prettyprint lang-scala">
+error: base is already defined as object base
+package base {
+        ^
+</pre>
 </li>
 
-<li>Prints:
+<li>Fails with the compile-time error
 <pre class="prettyprint lang-scala">
-object base
-package base
+error: type X is not a member of package base
+  println((new base.X).context)
+                    ^
 </pre>
 </li>
 
 <li id="correct-answer">Prints:
 <pre class="prettyprint lang-scala">
-object base
-object base
+error: type Y is not a member of object base
+  println((new base.Y).context)
+                    ^
 </pre>
 </li>
 
 <li>Prints:
 <pre class="prettyprint lang-scala">
-package base
+object base
 package base
 </pre>
 </li>
@@ -86,15 +93,18 @@ That package can neither be named nor imported, but the members of the empty pac
 without qualification.
 </p>
 <p>
-The example above defines the two classes <tt>base.X</tt> and <tt>&lt;empty&gt;.X</tt>, where the latter 
-is visible without qualification. Thus the code compiles fine and the first invocation prints
-<tt>object base</tt>. The import statement imports class <tt>X</tt> from object <tt>base</tt>, as this object is 
-visible here, and the second invocation prints <tt>object base</tt> as well.
+The example above defines the package <tt>base</tt> and the top-level object <tt>&lt;empty&gt;.base</tt>, where the latter 
+is visible without qualification, i.e. the object shadows the package.
+Thus the first <tt>println</tt> statement would compile fine and print
+<tt>object base</tt>.
+The access to <tt>base.Y</tt> in the second <tt>println</tt> statement leads to the compiler error
+<tt>type Y is not a member of object base</tt>.
 </p>
 <p>
-Class <tt>X</tt> in the package <tt>base</tt> can be accessed with a full qualified identifier:
+Class <tt>Y</tt> in package <tt>base</tt> can be accessed
+with a full qualified identifier:
 <pre class="prettyprint lang-scala">
-println((new _root_.base.X).context)
+println((new _root_.base.Y).context)
 </pre>
 </p>
 <p>


### PR DESCRIPTION
Puzzler 21 covers name-clashes for top-level classes. After having understood
the spec, it turns out, that top-level classes are not really useful, so this
question covers a rather unimportant part of the language. But let's look what
you think on that one.
