### PR TITLE
Fixes the display button message for some puzzlers

### DIFF
--- a/puzzlers/pzzlr-019.html
+++ b/puzzlers/pzzlr-019.html
@@ -60,7 +60,7 @@ f(2)
 </ol>
 
 </div>
-<button id="show-and-tell" class="btn btn-primary" href="#">Display the correct answer and explanation</button>
+<button id="show-and-tell" class="btn btn-primary" href="#">Display the correct answer, explanation and comments</button>
 <div id="explanation" class="explanation" style="display:none">
 <h3>Explanation</h3>
 <p>

--- a/puzzlers/pzzlr-020.html
+++ b/puzzlers/pzzlr-020.html
@@ -54,7 +54,7 @@ invert3(v1 = 2, v2 = 1)
 </ol>
 
 </div>
-<button id="show-and-tell" class="btn btn-primary" href="#">Display the correct answer and explanation</button>
+<button id="show-and-tell" class="btn btn-primary" href="#">Display the correct answer, explanation and comments</button>
 <div id="explanation" class="explanation" style="display:none">
 <h3>Explanation</h3>
 <p>

--- a/puzzlers/pzzlr-021.html
+++ b/puzzlers/pzzlr-021.html
@@ -72,7 +72,7 @@ package base
 </ol>
 
 </div>
-<button id="show-and-tell" class="btn btn-primary" href="#">Display the correct answer and explanation</button>
+<button id="show-and-tell" class="btn btn-primary" href="#">Display the correct answer, explanation and comments</button>
 <div id="explanation" class="explanation" style="display:none">
 <h3>Explanation</h3>
 <p>

--- a/puzzlers/pzzlr-022.html
+++ b/puzzlers/pzzlr-022.html
@@ -75,7 +75,7 @@ x = 2
 </ol>
 
 </div>
-<button id="show-and-tell" class="btn btn-primary" href="#">Display the correct answer and explanation</button>
+<button id="show-and-tell" class="btn btn-primary" href="#">Display the correct answer, explanation and comments</button>
 <div id="explanation" class="explanation" style="display:none">
 <h3>Explanation</h3>
 <p>


### PR DESCRIPTION
In the template, the text for the display butten was changed from
`Display the correct answer and explanation` to `Display the correct
answer, explanation and comments`. Four puzzlers still had the old
text.
