### PR TITLE
032: Type Extortion

### DIFF
--- a/puzzlers/pzzlr-032.html
+++ b/puzzlers/pzzlr-032.html
@@ -6,6 +6,10 @@
       <td>A. P. Marki</td>
     </tr>
     <tr>
+      <td class="header-column"><strong>Edited by</strong></td>
+      <td>Andrew Phillips</td>
+    </tr>
+    <tr>
       <td><strong>Source</strong></td>
       <td><a target="_blank" href="https://groups.google.com/d/topic/scala-user/KfNiYa1YoPM/discussion">scala-lang mailing list</a></td>
     </tr>
@@ -18,18 +22,11 @@
 <div class="code-snippet">
   <h3>What is the result of executing the following code?</h3>
 <pre class="prettyprint lang-scala">
-  val (x, y) = (List(1,3,5), List(2,4,6)).zipped find (_._1 > 10) getOrElse (10)
+  val (x, y) = (List(1,3,5), List(2,4,6)).zipped find (_._1 > 10) getOrElse (10)  // cap it at ... wait for it ... ten!
 
-Console println s"Found $x"
+  Console println s"Found $x"
 </pre>
   <ol>
-    <!--
-      The correct answer should have id for corresponding li element equal to "correct-answer".
-      When placing code snippets wrap them with pre tag:
-      <pre class="prettyprint lang-scala">
-        ...
-      </pre>
-     -->
     <li>Found 10</li>
     <li>Found ()</li>
     <li>Does not compile.</li>
@@ -39,14 +36,16 @@ Console println s"Found $x"
 <button id="show-and-tell" class="btn btn-primary" href="#">Display the correct answer, explanation and comments</button>
 <div id="explanation" class="explanation" style="display:none">
   <h3>Explanation</h3>
+  <blockquote>
   <p>
   The bully who stole your milk money used to say: "Give it to me -- or else!"
   </p>
   <p>
   But he was never satisfied and would always take as much as he could get.
   </p>
+  </blockquote>
   <p>
-In Scala, the "or else" idioms, such as Option.orElse, Option.getOrElse, or Try.recover and Future.recover,
+In Scala, the "or else" idioms, such as <tt>Option.orElse</tt>, <tt>Option.getOrElse</tt>, or <tt>Try.recover</tt> and <tt>Future.recover</tt>,
 are defined to accept a wider type than you start with:
   </p>
   <p>
@@ -57,36 +56,59 @@ are defined to accept a wider type than you start with:
   <p>
 If you don't supply a value of the type it wants, it will take whatever it can, including Any thing at all.
   </p>
-  <p>
+<p>
 In this case, Any is inferred for B, and there is no type error to show that an Int was used as an alternative
 for a pair of Ints. In the absence of a type on the pattern definition, the pattern match throws a MatchError
-at runtime.
-  </p>
-  <p>
-Even without a mistaken change in arity, similar typographic errors are possible with swapped elements:
-  </p>
-  <p>
-  <pre class="prettyprint lang-scala">
-  val (num, name) = Option(Pair(7, "seven")) getOrElse Pair("eight", 8)
-  </pre>
-  </p>
-  <p>
-That suggests that testing of these alternative code paths should be enforced by a code coverage tool.
-It may be that the "orElse" represents a default value that is never exercised in normal usage.
-  </p>
-  <p>
-  Fixes include specifying the expected type:
-  <pre class="prettyprint lang-scala">
-  val (num, name): (Int, String) = Option(Pair(7, "seven")) getOrElse Pair("eight", 8)
+at runtime:
+<pre class="prettyprint lang-scala">
+  scala> val (x, y) = (List(1,3,5), List(2,4,6)).zipped find (_._1 > 10) getOrElse (10)
+  scala.MatchError: 10 (of class java.lang.Integer)
+</pre>
+</p>
+Even without a mistaken change in arity, similar errors are possible with swapped elements:
+</p>
+<p>
+<pre class="prettyprint lang-scala">
+  def howToPronounce(numAndName: Option[(Int, String)]) = {
+    val (num, name) = numAndName getOrElse ("eight", 8)
+    println(s"The word for $num is '$name'")
+  }
+  howToPronounce(Some((7, "seven")))
+  howToPronounce(None)
+</pre>
+</p>
+<p>
+Since orElse often represents a default value that is typically not exercised in normal usage,
+the correctness of this branch of the code path should be checked by testing.
+And that's why we have code coverage tools.
+</p>
+<p>
+Ways to avoid this issue include:
+<pre class="prettyprint lang-scala">
+val (num, name): (Int, String) = Some((7, "seven")) getOrElse Pair("eight", 8)
+<console>:10: error: type mismatch;
+ found   : String("eight")
+ required: Int
+       val (num, name): (Int, String) = Some((7, "seven")) getOrElse Pair("eight", 8)
+                                                                          ^
+<console>:10: error: type mismatch;
+ found   : Int(8)
+ required: String
+       val (num, name): (Int, String) = Some((7, "seven")) getOrElse Pair("eight", 8)
+                                                                                   ^
   </pre>
   </p>
   <p>
   Or using a method that eliminates the inferred type:
   <pre class="prettyprint lang-scala">
-  implicit class OptionSafe[A](val opt: Option[A]) extends AnyVal {
-    def getOrElseSafe(default: => A): A = opt getOrElse default
-  }
-  val (num, name) = Option(Pair(7, "seven")) getOrElseSafe Pair("eight", 8)
-  </pre>
-  </p>
+implicit class OptionSafe[A](val opt: Option[A]) {
+  def getOrElseSafe(default: => A): A = opt getOrElse default
+}
+val (num, name) = Some((7, "seven")) getOrElseSafe Pair("eight", 8)
+<console>:16: error: type mismatch;
+ found   : String("eight")
+ required: Int
+         val (num, name) = Some((7, "seven")) getOrElseSafe Pair("eight", 8)
+                                                                 ^
+</pre>
 </div>


### PR DESCRIPTION
Explain unexpected type inference on Option.getOrElse, from the ML.

Extortion metaphor is used because after Boston one can't speak of
a type blowing up.

This example comes close to describing an edge case in a common idiom.
