### PR TITLE
All remaining errors are my own

### DIFF
--- a/puzzlers/pzzlr-036.html
+++ b/puzzlers/pzzlr-036.html
@@ -56,7 +56,8 @@ Puzzled yet?
   <h3>Explanation</h3>
   <p>
     The <tt>message</tt> parameter to the <tt>print</tt> routine is call-by-name. 
-    That's why the argument is evaluated twice.
+    The message argument is not evaluated until it is used, and it is evaluated
+    each time it is used.
   </p>
   <p>
     But the curly braces after the invocation of <tt>new Printer</tt> is not a call-by-name
@@ -79,7 +80,14 @@ Puzzled yet?
     The desired behavior was, presumably, for the prompt to be evaluated only when the <tt>prompted</tt>
     parameter is <tt>true</tt>, which can be achieved by the construction:
 <pre class="prettyprint lang-scala">
-val printer = new Printer{ prompt _ }
+scala> val printer = new Printer(prompt)
+printer: Printer = Printer@18bbd9e6
+
+scala> printer print (message = "Puzzled yet?", prompted = true)
+puzzler$ Puzzled yet?
+
+scala> printer print (message = "Puzzled yet?")
+Puzzled yet?
 </pre>
   </p>
 </div>


### PR DESCRIPTION
That includes these two.  In particular, the correct syntax for the fix is
supplied, which is kind of the point.

Someday, we will have the ability to run code from the browser to facilitate
testing the snippets.
