### PR TITLE
Improving the explanation of 'Captured by Closures'

### DIFF
--- a/puzzlers/pzzlr-008.html
+++ b/puzzlers/pzzlr-008.html
@@ -20,18 +20,20 @@
 <div class="code-snippet">
   <h3>What is the result of executing the following code?</h3>
 <pre class="prettyprint lang-scala">
-val values = Seq(100, 110, 120)
-val funcs1 = collection.mutable.Buffer[() => Int]()
-val funcs2 = collection.mutable.Buffer[() => Int]()
-var j = 0
-for (i <- 0 until values.length) {
- funcs1 += (() => values(i))
- funcs2 += (() => values(j))
- j += 1
+import collection.mutable.Buffer
+val funcs1 = Buffer[() => Int]()
+val funcs2 = Buffer[() => Int]()
+{
+  val values = Seq(100, 110, 120)
+  var j = 0
+  for (i <- 0 until values.length) {
+   funcs1 += (() => values(i))
+   funcs2 += (() => values(j))
+   j += 1
+  }
 }
-
-funcs1.foreach { f1 => println(f1()) }
-funcs2.foreach { f2 => println(f2()) }
+funcs1 foreach { f1 => println(f1()) }
+funcs2 foreach { f2 => println(f2()) }
 </pre>
   <ol>
     <!--
@@ -41,21 +43,29 @@ funcs2.foreach { f2 => println(f2()) }
         ...
       </pre>
      -->
-    <li id="correct-answer"><tt>funcs1</tt> prints
-      <pre class="prettyprint lang-scala">
-100, 110, 120</pre>
-      whereas <tt>funcs2</tt> throws an <tt>ArrayIndexOutOfBoundsException</tt></li>
-    <li>Both print
-      <pre class="prettyprint lang-scala">
-100, 110, 120</pre>
+    <li id="correct-answer">The first statement prints:
+<pre class="prettyprint lang-scala">
+100
+110
+120
+</pre>
+      and the second fails with an <tt>IndexOutOfBoundsException</tt>
     </li>
-    <li>The code does not compile</li>
-    <li><tt>funcs1</tt> prints
-      <pre class="prettyprint lang-scala">
-100, 110, 120</pre>
-      whereas <tt>funcs2</tt> prints
-      <pre class="prettyprint lang-scala">
-120, 120, 120</pre>
+    <li>Both statements print:
+<pre class="prettyprint lang-scala">
+100
+110
+120
+</pre>
+    </li>
+    <li>Both statements fail with a compilation exception <tt>error: not found: value values</tt>
+    </li>
+    <li>Both statements print:
+<pre class="prettyprint lang-scala">
+120
+120
+120
+</pre>
     </li>
   </ol>
 </div>
@@ -63,22 +73,31 @@ funcs2.foreach { f2 => println(f2()) }
 <div id="explanation" class="explanation" style="display:none">
   <h3>Explanation</h3>
   <p>
-  When one uses a <tt>var</tt> instead of a <tt>val</tt> the functions closes over a variable and not over a value. Because <tt>i</tt> is defined in the for-comprehension it is defined as a <tt>val</tt>. This means each time <tt>i</tt> is stored somewhere its value is copied - therefore it prints the expected result <tt>100, 110, 120</tt>. As <tt>j</tt> changes inside the loop, all the three closures "see" the very same variable <tt>j</tt> and not a copy of it. Because after the loop <tt>j</tt> is <tt>3</tt> an <tt>ArrayIndexOutOfBoundsException</tt> is thrown. It is possible to avoid the exception by &quot;fixing&quot; the value to be returned:
-  <pre class="prettyprint lang-scala">
-val values = Seq(100, 110, 120)
-val funcs1 = collection.mutable.Buffer[() => Int]()
-val funcs2 = collection.mutable.Buffer[() => Int]()
-var j = 0
-for (i <- 0 until values.length) {
- funcs1 += (() => values(i))
- val value = values(j)
- funcs2 += (() => value)
- j += 1
+  When one uses a <tt>var</tt> instead of a <tt>val</tt> the functions close over a variable and not over a value. Because <tt>i</tt> is defined in the for-comprehension it is defined as a <tt>val</tt>. This means each time <tt>i</tt> is stored somewhere its value is copied - therefore it prints the expected result:
+<pre class="prettyprint lang-scala">
+100
+110
+120
+</pre>
+  </p>
+  <p>As <tt>j</tt> changes inside the loop, all the three closures &quot;see&quot; the very same variable <tt>j</tt> and not a copy of it. Because after the loop <tt>j</tt> is <tt>3</tt> an <tt>IndexOutOfBoundsException</tt> is thrown. It is possible to avoid the exception by &quot;fixing&quot; the value to be returned:
+<pre class="prettyprint lang-scala">
+import collection.mutable.Buffer
+val funcs1 = Buffer[() => Int]()
+val funcs2 = Buffer[() => Int]()
+{
+  val values = Seq(100, 110, 120)
+  var j = 0
+  for (i <- 0 until values.length) {
+   funcs1 += (() => values(i))
+   val value = values(j)
+   funcs2 += (() => value)
+   j += 1
+  }
 }
-funcs1.foreach { f1 => println(f1()) }
-funcs2.foreach { f2 => println(f2()) }
-  </pre>
+funcs1 foreach { f1 => println(f1()) }
+funcs2 foreach { f2 => println(f2()) }
+</pre>
   <tt>value</tt>'s assignment is carried out immediately, and thus &quot;captures&quot; the intended element of <tt>values</tt>.
   </p>
 </div>
-


### PR DESCRIPTION
The new alternative suggestion actually results in the expected behaviour, rather than simply avoiding the runtime exception
