### PR TITLE
Correcting typo in explanation of 'A Case of Equality'

### DIFF
--- a/puzzlers/pzzlr-011.html
+++ b/puzzlers/pzzlr-011.html
@@ -101,7 +101,7 @@ itself does not provide a definition for one of these methods and <em>only</em> 
 a concrete definition is not given in some base class of the case class
 (except <tt>AnyRef</tt>).
 </p><p>
-In our example, the base trait <tt>SpyOnEquals</tt> of <tt>CCSpy</tt>provides an <tt>equals</tt>
+In our example, the base trait <tt>SpyOnEquals</tt> of <tt>CCSpy</tt> provides an <tt>equals</tt>
 method, so the case class does not provide its own definition and the
 comparison of two different instances returns <tt>false</tt>.
 </p><p>


### PR DESCRIPTION
Just a small typo in explanation of 'A Case of Equality' corrected.
