### PR TITLE
Adding a puzzler definition to the home page

### DIFF
--- a/css/bootstrap.min.css
+++ b/css/bootstrap.min.css
@@ -727,6 +727,7 @@ a.label:hover,a.badge:hover{color:#ffffff;text-decoration:none;cursor:pointer;}
 .footer{font-size:12px;border-top:1px solid #eeeeee;clear:both;padding:10px 0 20px;}
 .headline{padding:60px;margin-bottom:30px;background-color:#fff9d1;font-family:'Oxygen',Arial,sans-serif;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;}.headline h1{margin-bottom:0;font-size:48px;line-height:1;color:#002b5c;padding-bottom:20px;letter-spacing:1px;}
 .headline p{font-size:24px;font-weight:200;font-family:'Oxygen',Arial,sans-serif;line-height:27px;color:#002b5c;}
+.headline li{font-size:24px;font-weight:200;font-family:'Oxygen',Arial,sans-serif;line-height:27px;color:#002b5c;}
 .headline-unit{padding:20px;margin-bottom:30px;background-color:#ffffff;font-family:'Oxygen',Arial,sans-serif;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;}.headline-unit h2{margin-bottom:0;font-size:28px;line-height:1;color:#002b5c;letter-spacing:1px;padding-bottom:15px;}
 .headline-unit p{font-size:18px;font-weight:200;font-family:'Oxygen',Arial,sans-serif;line-height:27px;color:#002b5c;}
 .navbar .brand{font-family:'Russo One',Arial,sans-serif;font-size:32px;text-shadow:3px 3px 3px #000000;}

--- a/index.html
+++ b/index.html
@@ -199,11 +199,29 @@
             <div id="welcome-content" style="display:none">
               <div class="headline">
                 <h1>A fun way to learn more about
-                <img src="img/scala-logo.png" alt="Scala" style="padding-bottom:15px;padding-left:10px"/></h1><br/>
+                  <img src="img/scala-logo.png" alt="Scala" style="padding-bottom:15px;padding-left:10px"/>
+                </h1>
                 <p>
-                  Welcome to Scala Puzzlers, the collection of <i>Traps, Pitfalls and Corner Cases</i> in the Scala language.<br/><br/>
-                  Prepare to be surprised, entertained and...well, puzzled! What is presented here is a selection of seemingly simple examples which demonstrate that there's plenty of head-scratching left in Scala. Let your mind be challenged by unexpected and unintuitive behaviour and results and learn something in the process.     
-                  <br/><br/>
+                  Welcome to Scala Puzzlers, the collection of <i>Traps, Pitfalls
+                  and Corner Cases</i> in the Scala language.
+                </p>
+                <p><br/>
+                  Prepare to be surprised, entertained and...well, puzzled! What
+                  is presented here is a selection of seemingly simple examples
+                  which demonstrate that there's plenty of head-scratching left in
+                  Scala. Let your mind be challenged by unexpected and unintuitive
+                  behaviour and results and learn something in the process.
+                </p>
+                <p><br/>
+                  What is a puzzler? It should be:
+                  <ul>
+                    <li>an intentional language feature (so no bugs)</li>
+                    <li>not just weird because the reader doesn't know Scala</li>
+                    <li>&quot;surprising&quot; or &quot;non-intuitive&quot; to a 
+                    reasonably skilled Scala developer</li>
+                  </ul>
+                </p>
+                <p><br/>
                   Choose a puzzler from the left-hand list to get started!
                 </p>
               </div>


### PR DESCRIPTION
Prompted by [this comment](https://github.com/scalapuzzlers/scalapuzzlers.github.com/pull/109#issuecomment-49697099)

Current:

![image](https://cloud.githubusercontent.com/assets/223702/3661632/9618108c-11c2-11e4-83b3-93e06262c469.png)

New:

![image](https://cloud.githubusercontent.com/assets/223702/3661630/8d7ceb64-11c2-11e4-87d5-3140b9900c01.png)

Note: the first formatting commit is really separate from the functional commit and probably could be committed while this one is still in review. Just want to make sure we're not breaking the Javascript...
