### PR TITLE
fixed typo in puzzler 019 - incorrect function name

### DIFF
--- a/puzzlers/pzzlr-019.html
+++ b/puzzlers/pzzlr-019.html
@@ -43,13 +43,13 @@ addTo1(2)(3)
 6
 </pre>
   </li>
-  <li id="correct-answer">The first invocation of <tt>f</tt> prints:
+  <li id="correct-answer">The first invocation of <tt>addTo1</tt> prints:
 <pre class="prettyprint lang-scala">
 5
 </pre>
 and the second fails to compile
   </li>
-  <li>The first invocation of <tt>f</tt> fails to compile and the second prints:
+  <li>The first invocation of <tt>addTo1</tt> fails to compile and the second prints:
 <pre class="prettyprint lang-scala">
 6
 </pre>


### PR DESCRIPTION
I have noticed a small typo in the function name in the answers in puzzler 019