### PR TITLE
matching on objects with lower-case first letters

### DIFF
--- a/puzzlers/pzzlr-072.html
+++ b/puzzlers/pzzlr-072.html
@@ -1,0 +1,70 @@
+<h1>Matching on <code>object</code>s with lower-case first letters</h1>
+<table class="table meta-table table-condensed">
+  <tbody>
+    <tr>
+      <td class="header-column"><strong>Contributed by</strong></td>
+      <td><a href="https://github.com/ryan-williams">Ryan Williams</a>, <a href="https://github.com/martijnhoekstra">Martijn Hoekstra</a></td>
+    </tr>
+    <tr>
+      <td><strong>Source</strong></td>
+      <!--
+        If no source (your puzzler is not mentioned anywhere on the web), just say N/A
+      --> 
+      <td><a target="_blank" href="https://gitter.im/scala/scala?at=5b68cf3085278d705e9332fc">scala/scala Gitter</a></td>
+    </tr>
+    <tr>
+      <td><strong>First tested with Scala version</strong></td>
+      <td>2.12.6</td>
+    </tr>
+  </tbody>
+</table>
+<div class="code-snippet">
+  <h3>What is the result of executing the following code?</h3>
+<pre class="prettyprint lang-scala">
+sealed trait obj
+case object one extends obj
+case object two extends obj
+def test(o: obj) =
+  o match {
+    case one ⇒ 1
+    case two ⇒ 2
+  }
+println(test(one))
+println(test(two))
+</pre>
+  <ol>
+    <!--
+      The correct answer should have id for corresponding li element equal to "correct-answer".
+      When placing code snippets wrap them with pre tag:
+      <pre class="prettyprint lang-scala">
+        ...
+      </pre>
+     -->
+    <li>prints "1" and then "2"</li>
+    <li>throws <code>MatchError</code></li>
+    <li id="correct-answer">prints "1" and then "1"</li>
+    <li>compile error</li>
+  </ol>
+</div>
+<button id="show-and-tell" class="btn btn-primary" href="#">Display the correct answer, explanation and comments</button>
+<div id="explanation" class="explanation" style="display:none">
+  <h3>Explanation</h3>
+  <p>
+    Identifiers that start with a lower-case letter are treated as a new variable with that name, whose value is the
+    input to the <code>match</code> expression.
+
+    Generally, you don't want to do this unless it's the last, "catch-all" <code>case</code>.
+
+    To correctly <code>match</code> on the <code>object</code>s above, you'd have to do:
+
+<pre class="prettyprint lang-scala">
+def ok(o: obj) =
+  o match {
+    case _: one.type ⇒ 1
+    case _: two.type ⇒ 2
+  }
+</pre>
+  You can also <a href="https://gist.github.com/ryan-williams/16914966e656385108c75b681f9f3c5d">make them 0-arg
+  <code>case class</code>es, capitalize their first letter, or put their names in backticks</a>.
+  </p>
+</div>


### PR DESCRIPTION
- reusing id `072` since idk if #153 still has the lock on it
- could use a better name
- [relevant gitter discussion](https://gitter.im/scala/scala?at=5b68cf3085278d705e9332fc)